### PR TITLE
Create update-antora-ui-spring.yml

### DIFF
--- a/.github/workflows/update-antora-ui-spring.yml
+++ b/.github/workflows/update-antora-ui-spring.yml
@@ -1,0 +1,50 @@
+name: Update Antora UI Spring
+
+on:
+  workflow_call:
+    inputs:
+      docs-branch:
+        description: Branch used by Antora, defaults to docs-build
+        required: false
+        default: 'docs-build'
+        type: string
+    secrets:
+      token:
+        description: Token to use the GH CLI and to Open PRs
+        required: true
+
+jobs:
+  update-antora-ui-spring:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.docs-branch }}
+          fetch-depth: 1
+      - name: Get Current UI Bundle URL
+        uses: mikefarah/yq@v4.43.1
+        id: current
+        with:
+          cmd: yq '.ui.bundle.url' antora-playbook.yml
+      - name: Get Latest UI Bundle URL
+        id: latest
+        run: |
+          echo latest_ui_bundle_url=$(gh api /repos/spring-io/antora-ui-spring/releases/latest | jq -r '.assets[] | select(.name == "ui-bundle.zip") | .browser_download_url') >> $GITHUB_OUTPUT
+          echo tag_name=$(gh api /repos/spring-io/antora-ui-spring/releases/latest | jq -r '.tag_name') >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+      - name: Replace Current with Latest
+        id: replace
+        if: ${{ steps.current.outputs.result != steps.latest.outputs.latest_ui_bundle_url }}
+        run: |
+          sed -i 's@${{ steps.current.outputs.result }}@${{ steps.latest.outputs.latest_ui_bundle_url }}@g' antora-playbook.yml
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.token }}
+          title: Update Antora UI Spring to ${{ steps.latest.outputs.tag_name }}
+          body: Automated changes
+          commit-message: Update Antora UI Spring to ${{ steps.latest.outputs.tag_name }}
+          delete-branch: true
+          base: ${{ inputs.docs-branch }}


### PR DESCRIPTION
Add reusable workflow that can be used to update the version of Antora UI Spring inside the `antora-playbook.yml` file.

Example usage https://github.com/spring-projects/spring-security/blob/main/.github/workflows/update-antora-ui-spring.yml