### PR TITLE
Fix update-antora-ui-spring README example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,19 +121,23 @@ permissions:
 jobs:
   update-antora-ui-spring:
     runs-on: ubuntu-latest
-    name: Update
+    name: Update on Supported Branches
     strategy:
       matrix:
         branch: [ '5.8.x', '6.1.x', '6.2.x', 'main' ]
     steps:
       - uses: spring-io/spring-doc-actions/update-antora-spring-ui@{ACTION_VERSION}
-        name: Update on Supported Branches
+        name: Update
         with:
           docs-branch: ${{ matrix.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
           antora-file-path: 'docs/antora-playbook.yml'
+  update-antora-ui-spring-docs-build:
+    runs-on: ubuntu-latest
+    name: Update on docs-build
+    steps:
       - uses: spring-io/spring-doc-actions/update-antora-spring-ui@{ACTION_VERSION}
-        name: Update on docs-build
+        name: Update
         with:
           docs-branch: 'docs-build'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Move the step that updates only one branch to a different job, avoiding running it multiple times since the previous job used a matrix strategy